### PR TITLE
Relax PHPUnit requirement to 3.x as this is all CakePHP 2.x supports. Some additional documentation

### DIFF
--- a/Controller/Component/Auth/JwtTokenAuthenticate.php
+++ b/Controller/Component/Auth/JwtTokenAuthenticate.php
@@ -1,7 +1,5 @@
 <?php
 App::uses('BaseAuthenticate', 'Controller/Component/Auth');
-$path = CakePlugin::path('JwtAuth');
-require_once($path . DS . 'vendor' . DS . 'firebase' . DS . 'php-jwt' . DS . 'Firebase' . DS . 'PHP-JWT' . DS . 'Authentication' . DS . 'JWT.php');
 
 /**
  * An authentication adapter for AuthComponent.  Provides the ability to authenticate using a Json Web Token

--- a/Controller/Component/Auth/JwtTokenAuthenticate.php
+++ b/Controller/Component/Auth/JwtTokenAuthenticate.php
@@ -25,6 +25,7 @@ App::uses('BaseAuthenticate', 'Controller/Component/Auth');
  * @license MIT
  * @link https://github.com/ceeram/Authenticate
  */
+
 class JwtTokenAuthenticate extends BaseAuthenticate
 {
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         {
             "name": "Florian Krämer"
         }
+    ],
     "require": {
         "firebase/php-jwt": "~2.0",
         "composer/installers": "*",

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,10 @@
         {
             "name": "Florian Krämer"
         }
-    ],
     "require": {
         "firebase/php-jwt": "~2.0",
         "composer/installers": "*",
-        "phpunit/phpunit": "~4.6"
+        "phpunit/phpunit": "3.*"
     },
     "extra": {
         "installer-name": "JwtAuth"

--- a/readme.md
+++ b/readme.md
@@ -46,8 +46,81 @@ http://github.com/t73biz
 
 ```composer require t73biz/cakephp2-jwt-auth 1.0.6```
 
-This will install into the Plugin directory. To run the tests, simply navigate to your webroot/test.php and follow the links for the test cases for the Authentication Adapter.
- 
+This will install into the Plugin directory (in the ```JwtAuth``` folder). To run the tests, simply navigate to your webroot/test.php and follow the links for the test cases for the Authentication Adapter.
+
+## Usage ##
+
+### Configuration ###
+
+You can either declare this in your Controller's ```$components``` array, or on the fly in an ```action``` (if you need to load any configuration values, which you can't do when declaring in the ```$components``` array, for example).
+
+```
+public $components = array(
+    'Auth' => array(
+        'authenticate' => array(
+            'JwtAuth.JwtToken' => array(
+                'fields' => array(
+                    'username' => 'username',
+                    'password' => 'password',
+                    'token' => 'public_key',
+                ),
+                'parameter' => '_token',
+                'userModel' => 'User',
+                'scope' => array('User.active' => 1),
+                'pepper' => 'sneezing',
+            ),
+        ),
+    ),
+);
+```
+Or
+```
+$this->Auth->authenticate['JwtAuth.JwtToken'] = array(
+    'fields' => array(
+        'username' => 'username',
+        'password' => 'password',
+        'token' => 'public_key',
+    ),
+    'parameter' => '_token',
+    'userModel' => 'User',
+    'scope' => array('User.active' => 1),
+    'pepper' => Configure::read('API.token.pepper'),
+);
+```
+
+Where (excluding common authentication items):
+
+- ```fields``` is an array containing the details of which passed values (POSTed) contain the ```username```, ```password``` and ```token```
+  - ```token``` is used to hold a unique key against the user once authenticated and is also stored in the JWT
+- ```parameter``` is the query string parameter that could hold the JWT
+- ```header``` is the HTTP header that could hold the JWT
+- ```pepper``` is the salt to use when encrypting your JWT (keep this super secret!)
+
+#### Defaults ####
+
+```
+array(
+    'fields' => array(
+        'username' => 'username',
+        'token' => 'token'
+    ),
+    'parameter' => '_token',
+    'header' => 'X_JSON_WEB_TOKEN',
+    'userModel' => 'User',
+    'scope' => array(),
+    'recursive' => 0,
+    'contain' => null,
+    'pepper' => '123'
+);
+```
+
+### Authentication ###
+
+You can authenticate by passing a valid JWT as either:
+
+- The query string parameter defined as ```parameter``` in the config array (defaults to ```_token```)
+- The contents of the header defined as ```header``` in the config array (defaults to ```X_JSON_WEB_TOKEN```)
+
 ## TODO ##
 
 Implement an end to end example for inside clients and 3rd party client usage.


### PR DESCRIPTION
- Relaxed PHPUnit requirement to 3.*
- Added some usage and configuration documentation
- Fixed a bug I introduced in composer.json
- Removed require from JwtTokenAuthentication as if installing with composer the Composer autoloader will find the JWT class for us
